### PR TITLE
adds support for optional "www." and "http(s)://"

### DIFF
--- a/lib/youtube_id.rb
+++ b/lib/youtube_id.rb
@@ -2,11 +2,11 @@ require "youtube_id/version"
 
 module YoutubeID
   FORMATS = [
-    %r(https?://youtu\.be/(.+)),
-    %r(https?://www\.youtube\.com/watch\?v=(.*?)(&|#|$)),
-    %r(https?://www\.youtube\.com/embed/(.*?)(\?|$)),
-    %r(https?://www\.youtube\.com/v/(.*?)(#|\?|$)),
-    %r(https?://www\.youtube\.com/user/.*?#\w/\w/\w/\w/(.+)\b)
+    %r((?:https?://)?youtu\.be/(.+)),
+    %r((?:https?://)?(?:www\.)?youtube\.com/watch\?v=(.*?)(&|#|$)),
+    %r((?:https?://)?(?:www\.)?youtube\.com/embed/(.*?)(\?|$)),
+    %r((?:https?://)?(?:www\.)?youtube\.com/v/(.*?)(#|\?|$)),
+    %r((?:https?://)?(?:www\.)?youtube\.com/user/.*?#\w/\w/\w/\w/(.+)\b)
   ]
 
   def self.from(video_url)

--- a/spec/youtube_id_spec.rb
+++ b/spec/youtube_id_spec.rb
@@ -4,54 +4,56 @@ describe YoutubeID do
   describe ".from" do
     subject { described_class.from url }
 
-    %w(http https).each do |protocol|
-      context "direct format" "/v/:id" do
-        let(:url) { "#{protocol}://www.youtube.com/v/RCUkmUXMd_k" }
-        it { should == "RCUkmUXMd_k" }
-      end
-
-      context "legacy embed format" "/v/:id?version=3&amp;hl=en_US&amp;rel=0" do
-        let(:url) { "#{protocol}://www.youtube.com/v/RCUkmUXMd_k?version=3&amp;hl=en_US&amp;rel=0" }
-        it { should == "RCUkmUXMd_k" }
-      end
-
-      context "embed format" "/embed/RCUkmUXMd_k?rel=0" do
-        let(:url) { "#{protocol}://www.youtube.com/embed/RCUkmUXMd_k?rel=0" }
-        it { should == "RCUkmUXMd_k" }
-
-        context "without parameters" do
-          let(:url) { "#{protocol}://www.youtube.com/embed/RCUkmUXMd_k" }
-          it { should == "RCUkmUXMd_k" }
-        end
-      end
-
-      context "standard format", "/watch?v=:id" do
-        let(:url) { "#{protocol}://www.youtube.com/watch?v=RCUkmUXMd_k" }
-        it { should == "RCUkmUXMd_k" }
-
-        context "with additional parameters" do
-          let(:url) { "#{protocol}://www.youtube.com/watch?v=RCUkmUXMd_k&feature=related" }
+    ["", "http://", "https://"].each do |protocol|
+      ["", "www."].each do |www|
+        context "direct format" "/v/:id" do
+          let(:url) { "#{protocol}#{www}youtube.com/v/RCUkmUXMd_k" }
           it { should == "RCUkmUXMd_k" }
         end
 
-        context "with start time specification" do
-          let(:url) { "#{protocol}://www.youtube.com/watch?v=RCUkmUXMd_k#t=0m10s" }
+        context "legacy embed format" "/v/:id?version=3&amp;hl=en_US&amp;rel=0" do
+          let(:url) { "#{protocol}#{www}youtube.com/v/RCUkmUXMd_k?version=3&amp;hl=en_US&amp;rel=0" }
           it { should == "RCUkmUXMd_k" }
         end
-      end
 
-      context "user video format", "/user/name#p/a/u/0/:id" do
-        let(:url) { "#{protocol}://www.youtube.com/user/ForceD3strategy#p/a/u/0/8WVTOUh53QY" }
-        it { should == "8WVTOUh53QY" }
+        context "embed format" "/embed/RCUkmUXMd_k?rel=0" do
+          let(:url) { "#{protocol}#{www}youtube.com/embed/RCUkmUXMd_k?rel=0" }
+          it { should == "RCUkmUXMd_k" }
+
+          context "without parameters" do
+            let(:url) { "#{protocol}#{www}youtube.com/embed/RCUkmUXMd_k" }
+            it { should == "RCUkmUXMd_k" }
+          end
+        end
+
+        context "standard format", "/watch?v=:id" do
+          let(:url) { "#{protocol}#{www}youtube.com/watch?v=RCUkmUXMd_k" }
+          it { should == "RCUkmUXMd_k" }
+
+          context "with additional parameters" do
+            let(:url) { "#{protocol}#{www}youtube.com/watch?v=RCUkmUXMd_k&feature=related" }
+            it { should == "RCUkmUXMd_k" }
+          end
+
+          context "with start time specification" do
+            let(:url) { "#{protocol}#{www}youtube.com/watch?v=RCUkmUXMd_k#t=0m10s" }
+            it { should == "RCUkmUXMd_k" }
+          end
+        end
+
+        context "user video format", "/user/name#p/a/u/0/:id" do
+          let(:url) { "#{protocol}#{www}youtube.com/user/ForceD3strategy#p/a/u/0/8WVTOUh53QY" }
+          it { should == "8WVTOUh53QY" }
+        end
       end
 
       context "short url format", "//youtu.be/RCUkmUXMd_k" do
-        let(:url) { "#{protocol}://youtu.be/RCUkmUXMd_k" }
+        let(:url) { "#{protocol}youtu.be/RCUkmUXMd_k" }
         it { should == "RCUkmUXMd_k" }
       end
 
       context "short url format with dashes", "//youtu.be/Hu0i--4tz0N" do
-        let(:url) { "#{protocol}://youtu.be/Hu0i--4tz0N" }
+        let(:url) { "#{protocol}youtu.be/Hu0i--4tz0N" }
         it { should == "Hu0i--4tz0N" }
       end
     end


### PR DESCRIPTION
Allows omission of "www." and/or "http(s)://", i.e.:

http://youtube.com/embed/RCUkmUXMd_k
youtube.com/embed/RCUkmUXMd_k
www.youtube.com/embed/RCUkmUXMd_k

These formats are now all valid.