### PR TITLE
Change format of short youtube links

### DIFF
--- a/lib/youtube_id.rb
+++ b/lib/youtube_id.rb
@@ -1,12 +1,13 @@
-require "youtube_id/version"
+require 'youtube_id/version'
 
 module YoutubeID
   FORMATS = [
-    %r((?:https?://)?youtu\.be/(.*?)(\?|$|#|&)),
-    %r((?:https?://)?(?:www\.)?youtube\.com/watch\?v=(.*?)(&|#|$)),
-    %r((?:https?://)?(?:www\.)?youtube\.com/embed/(.*?)(\?|$)),
-    %r((?:https?://)?(?:www\.)?youtube\.com/v/(.*?)(#|\?|$)),
-    %r((?:https?://)?(?:www\.)?youtube\.com/user/.*?#\w/\w/\w/\w/(.+)\b)
+    %r{(?:https?://)?youtu\.be/(.*?)(\?|$|#|&)},
+    %r{(?:https?://)?(?:www\.)?youtube\.com/watch\?v=(.*?)(&|#|$)},
+    %r{(?:https?://)?(?:www\.)?youtube\.com/watch\?.*?v=(.*?)(&|#|$)},
+    %r{(?:https?://)?(?:www\.)?youtube\.com/embed/(.*?)(\?|$)},
+    %r{(?:https?://)?(?:www\.)?youtube\.com/v/(.*?)(#|\?|$)},
+    %r{(?:https?://)?(?:www\.)?youtube\.com/user/.*?#\w/\w/\w/\w/(.+)\b}
   ].freeze
 
   def self.from(video_url)

--- a/lib/youtube_id.rb
+++ b/lib/youtube_id.rb
@@ -2,12 +2,12 @@ require "youtube_id/version"
 
 module YoutubeID
   FORMATS = [
-    %r((?:https?://)?youtu\.be/(.+)),
+    %r((?:https?://)?youtu\.be/(.*?)(\?|$|#|&)),
     %r((?:https?://)?(?:www\.)?youtube\.com/watch\?v=(.*?)(&|#|$)),
     %r((?:https?://)?(?:www\.)?youtube\.com/embed/(.*?)(\?|$)),
     %r((?:https?://)?(?:www\.)?youtube\.com/v/(.*?)(#|\?|$)),
     %r((?:https?://)?(?:www\.)?youtube\.com/user/.*?#\w/\w/\w/\w/(.+)\b)
-  ]
+  ].freeze
 
   def self.from(video_url)
     video_url.strip!

--- a/spec/youtube_id_spec.rb
+++ b/spec/youtube_id_spec.rb
@@ -45,6 +45,11 @@ describe YoutubeID do
           let(:url) { "#{protocol}#{www}youtube.com/user/ForceD3strategy#p/a/u/0/8WVTOUh53QY" }
           it { should == "8WVTOUh53QY" }
         end
+
+        context "url format with id in the end in list of parameters", "watch?list=PL0jiIBuf0E6uUMHmiqDYOXAsobF39knBs&time_continue=1&v=Hu0i--4tz0N" do
+          let(:url) { "#{protocol}#{www}youtube.com/watch?list=PL0jiIBuf0E6uUMHmiqDYOXAsobF39knBs&time_continue=1&v=Hu0i--4tz0N" }
+          it { should == "Hu0i--4tz0N" }
+        end
       end
 
       context "short url format", "//youtu.be/RCUkmUXMd_k" do


### PR DESCRIPTION
Add possibility to get video id from several types of short Youtube links.
There may be a lot of parameters after id in youtube link, e.g. '?enablejsapi=1&rel=0&showinfo=0'
Also, add supporting of url formats where id is in the end of parameters list.